### PR TITLE
chore: install Python with Posit's pre-compiled binaries (for Ubuntu)

### DIFF
--- a/tasks/debian/main.yml
+++ b/tasks/debian/main.yml
@@ -10,7 +10,7 @@
 
 - name: Install additional python versions | Set release version
   ansible.builtin.set_fact:
-    ubuntu_release: "{{ ansible_facts['distribution_version'] | replace('.','') }}"
+    ubuntu_release: "{{ ansible_facts['distribution_version'] | replace('.', '') }}"
   when: ansible_facts['distribution'] == "Ubuntu"
   tags:
     - python-install-set-facts

--- a/tasks/debian/main.yml
+++ b/tasks/debian/main.yml
@@ -1,6 +1,5 @@
 ---
-
-- name: Install additional python versions | install system dependencies
+- name: Install additional python versions | Install system dependencies
   ansible.builtin.apt:
     pkg: "{{ python_system_dependecies }}"
     state: "{{ apt_install_state | default('latest') }}"
@@ -9,87 +8,28 @@
   tags:
     - python-install-system-dependecies
 
-- name: Install additional python versions | download python
+- name: Install additional python versions | Set release version
+  ansible.builtin.set_fact:
+    ubuntu_release: "{{ ansible_facts['distribution_version'] | replace('.','') }}"
+  when: ansible_facts['distribution'] == "Ubuntu"
+  tags:
+    - python-install-set-facts
+    - python-install-setup-versions
+
+- name: Install additional python versions | Download deb package
   ansible.builtin.get_url:
-    url: "https://www.python.org/ftp/python/{{ item }}/Python-{{ item }}.tgz"
-    dest: "/tmp/Python-{{ item }}.tgz"
+    url: "https://cdn.rstudio.com/python/ubuntu-{{ ubuntu_release }}/pkgs/python-{{ item }}_1_amd64.deb"
+    dest: "/tmp/Python-{{ item }}.deb"
     mode: "0644"
   loop: "{{ python_versions }}"
   tags:
     - python-install-download-archives
     - python-install-setup-versions
 
-- name: Install additional python versions | extract python
-  ansible.builtin.unarchive:
-    remote_src: true
-    src: "/tmp/Python-{{ item }}.tgz"
-    dest: "/tmp"
+- name: Install additional python versions | Install deb package
+  ansible.builtin.apt:
+    deb: "/tmp/Python-{{ item }}.deb"
   loop: "{{ python_versions }}"
   tags:
-    - python-install-extract-archives
-    - python-install-setup-versions
-
-- name: Install additional python versions | configure python
-  ansible.builtin.command: >
-    ./configure \
-    --prefix=/opt/python/{{ item }}
-    --enable-shared
-    --enable-ipv6
-    LDFLAGS=-Wl,-rpath=/opt/python/{{ item }}/lib,--disable-new-dtags
-  args:
-    chdir: /tmp/Python-{{ item }}
-    creates: /tmp/Python-{{ item }}/Makefile
-  loop: "{{ python_versions }}"
-  tags:
-    - python-install-configure-python
-    - python-install-setup-versions
-
-- name: Install additional python versions | make python
-  ansible.builtin.command: >
-    make
-  args:
-    chdir: /tmp/Python-{{ item }}
-    creates: /tmp/Python-{{ item }}/python-config
-  loop: "{{ python_versions }}"
-  tags:
-    - python-install-make
-    - python-install-setup-versions
-
-- name: Install additional python versions | install python
-  ansible.builtin.command: >
-    make install
-  args:
-    chdir: /tmp/Python-{{ item }}
-    creates: /opt/python/{{ item }}/bin/python3
-  loop: "{{ python_versions }}"
-  tags:
-    - python-install-make-install
-    - python-install-setup-versions
-
-- name: Install additional python versions | download pip script
-  ansible.builtin.get_url:
-    url: "https://bootstrap.pypa.io/get-pip.py"
-    dest: "/tmp/get-pip.py"
-    mode: "0644"
-  tags:
-    - python-install-download-pip-script
-    - python-install-setup-versions
-
-- name: Install additional python versions | install pip
-  ansible.builtin.command: >
-    /opt/python/{{ item }}/bin/python3 /tmp/get-pip.py
-  changed_when: false
-  loop: "{{ python_versions }}"
-  tags:
-    - python-install-install-pip
-    - python-install-setup-versions
-
-- name: Install additional python versions | install virtualenv
-  ansible.builtin.command: >
-    /opt/python/{{ item }}/bin/pip install virtualenv
-  args:
-    creates: /opt/python/{{ item }}/bin/virtualenv
-  loop: "{{ python_versions }}"
-  tags:
-    - python-install-install-virtualenv
+    - python-install-install-archives
     - python-install-setup-versions


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

## Changes description

Changed Python installation method - the current recommended way by Posit is to use their pre-compiled binaries ([docs](https://docs.posit.co/resources/install-python/))
